### PR TITLE
Correção do nome da variável de classes

### DIFF
--- a/docs/egua/classes.md
+++ b/docs/egua/classes.md
@@ -18,7 +18,7 @@ A instância de uma classe é criada a partir da chamada de uma classe, ou seja,
 classe Teste {}
 
 var teste = Teste();
-escreva(test); // escreve "<Teste instância>"
+escreva(teste); // escreve "<Teste instância>"
 ```
 
 ## Métodos
@@ -73,7 +73,7 @@ classe Teste {
 }
 
 var teste = Teste();
-test.testeFuncao();
+teste.testeFuncao();
 ```
 
 ## Construtor


### PR DESCRIPTION
Alguns exemplos estavam acessando a variável `test`, porém, a definição era feita em `teste`.