### PR TITLE
Corrige nome do estado "Pará"

### DIFF
--- a/docs/introducao/README.md
+++ b/docs/introducao/README.md
@@ -6,6 +6,6 @@ description: Uma linguagem de programação simples e moderna para aprender a pr
 
 ## Introdução
 
-Egua é uma linguagem de programação nascida e mantida em Belém do pará. O principal objetivo da linguagem é auxiliar no aprendizado de lógica de programação em língua portuguesa, visto que todos os comandos da linguagem são feitos em português, fazendo com que os desenvolvedores que não possuem conhecimento da língua inglesa consigam entender de fato o código escrito.
+Egua é uma linguagem de programação nascida e mantida em Belém do Pará. O principal objetivo da linguagem é auxiliar no aprendizado de lógica de programação em língua portuguesa, visto que todos os comandos da linguagem são feitos em português, fazendo com que os desenvolvedores que não possuem conhecimento da língua inglesa consigam entender de fato o código escrito.
 
 Egua é uma linguagem em código aberto e gratuita para a utilização de todos.


### PR DESCRIPTION
Na documentação da introdução, o nome do estado estava com a letra inicial em minúsculo 