### PR TITLE
Corrigir o comentário de uma comparação

### DIFF
--- a/docs/egua/fluxo_controle.md
+++ b/docs/egua/fluxo_controle.md
@@ -15,7 +15,7 @@ Para que dois objetos sejam comparados como verdade, eles devem ser do mesmo tip
 "1" == "1"; // Verdade
 nulo == nulo; // Verdade
 
-"1" == "2"; // Verdade
+"1" == "2"; // Falsa
 1 == 2; // Falsa
 1 == "1"; // Falsa
 ```


### PR DESCRIPTION
A comparação "1" == "2", que deveria ser falsa, foi anotada como verdadeira. Conforme a documentação descreve:
"Para que dois objetos sejam comparados como verdade, eles devem ser do mesmo tipo e do **mesmo valor**".

(é meu primeiro pull request, qualquer erro me desculpe!)