### PR TITLE
corrigindo exemplo de palavras chaves de controle

### DIFF
--- a/docs/egua/fluxo_controle.md
+++ b/docs/egua/fluxo_controle.md
@@ -46,8 +46,8 @@ A Egua inclui várias palavras-chave que ajudam no fluxo de controle.
 - `em` - Retorna verdadeiro se o valor da esquerda estiver incluído no valor da direita.
 
 ```js
-verdadeiro e falso; // Verdade
-verdadeiro e falso; // Verdade
+verdadeiro e verdadeiro; // Verdade
+verdadeiro e falso; // Falso
 
 falso ou falso; // Falso
 verdadeiro ou falso; // Verdade


### PR DESCRIPTION
No exemplo apresentado no site, é dito que se é utilizado o operador booleano "e", será retornando verdade se ambos os valores forem verdadeiros. O exemplo atual estava dizendo que o caso "verdadeiro e falso" é verdade.